### PR TITLE
[closes #40] Add support for GenerateReport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,13 @@
 			<version>1.8.4</version>
 		</dependency>
 
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.5</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/jboss/qa/phaser/ExecutionNode.java
+++ b/src/main/java/org/jboss/qa/phaser/ExecutionNode.java
@@ -21,6 +21,7 @@ import org.jboss.qa.phaser.processors.MethodExecutor;
 import org.jboss.qa.phaser.registry.CreateAnnotationProcessor;
 import org.jboss.qa.phaser.registry.InjectAnnotationProcessor;
 import org.jboss.qa.phaser.registry.InstanceRegistry;
+import org.jboss.qa.phaser.util.XmlUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -75,11 +76,20 @@ public class ExecutionNode {
 				}
 				builder.build().invokeMethod(method, phaseDefinition.getJob());
 			}
+			generateXmlReport(null);
 			return null; // ok, no exception
 		} catch (InvocationTargetException e) {
+			generateXmlReport(e);
 			return generateExecutionError(e.getCause());
 		} catch (Throwable e) {
+			generateXmlReport(e);
 			return generateExecutionError(e);
+		}
+	}
+
+	private void generateXmlReport(Throwable e) {
+		if (phaseDefinition.getGenerateReport()) {
+			XmlUtils.generateReport(e, phaseDefinition);
 		}
 	}
 

--- a/src/main/java/org/jboss/qa/phaser/GenerateReport.java
+++ b/src/main/java/org/jboss/qa/phaser/GenerateReport.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.qa.phaser;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface GenerateReport {
+}

--- a/src/main/java/org/jboss/qa/phaser/Phase.java
+++ b/src/main/java/org/jboss/qa/phaser/Phase.java
@@ -63,6 +63,14 @@ public abstract class Phase<B extends PhaseDefinitionProcessorBuilder<A>, A exte
 			runAlways = true;
 		}
 
+		boolean generateReport = false;
+		final String reportValues = ReflectionUtils.invokeAnnotationMethod(annotation, GenerateReport.class);
+		if (reportValues != null && !reportValues.isEmpty()) {
+			generateReport = Boolean.parseBoolean(raValues);
+		} else if (method != null && method.isAnnotationPresent(GenerateReport.class)) {
+			generateReport = true;
+		}
+
 		ExceptionHandling eh = null;
 		OnException onExp = ReflectionUtils.invokeAnnotationMethod(annotation, OnExceptionDefinition.class);
 		if (onExp == null && method != null) {
@@ -81,6 +89,7 @@ public abstract class Phase<B extends PhaseDefinitionProcessorBuilder<A>, A exte
 				this,
 				annotation,
 				job,
-				method);
+				method,
+				generateReport);
 	}
 }

--- a/src/main/java/org/jboss/qa/phaser/PhaseDefinition.java
+++ b/src/main/java/org/jboss/qa/phaser/PhaseDefinition.java
@@ -34,6 +34,7 @@ public class PhaseDefinition<A extends Annotation> implements Comparable<PhaseDe
 	@NonNull @Getter private A annotation;
 	@NonNull @Getter private Object job;
 	@Getter private Method method;
+	@Getter private Boolean generateReport;
 
 	@Override
 	public int compareTo(PhaseDefinition o) {

--- a/src/main/java/org/jboss/qa/phaser/PhaseValidator.java
+++ b/src/main/java/org/jboss/qa/phaser/PhaseValidator.java
@@ -67,10 +67,19 @@ public final class PhaseValidator {
 		}
 	}
 
+	private static void validateGenerateReportType(Phase phase) throws PhaseValidationException {
+		for (Method m : phase.getAnnotationClass().getMethods()) {
+			if (m.isAnnotationPresent(GenerateReport.class) && !m.getReturnType().equals(Boolean.class)) {
+				throw new PhaseValidationException(GenerateReport.class.getName() + " method does not return Boolean in " + phase.getAnnotationClass().getCanonicalName() + "but returns" + m.getReturnType());
+			}
+		}
+	}
+
 	public static void validate(Phase phase) throws PhaseValidationException {
 		validateIdPresence(phase);
 		validateOrderType(phase);
 		validateRunAllwaysType(phase);
+		validateGenerateReportType(phase);
 	}
 
 	private PhaseValidator() {

--- a/src/main/java/org/jboss/qa/phaser/util/XmlUtils.java
+++ b/src/main/java/org/jboss/qa/phaser/util/XmlUtils.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.qa.phaser.util;
+
+import org.jboss.qa.phaser.PhaseDefinition;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import java.io.File;
+import java.util.Enumeration;
+import java.util.Properties;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class XmlUtils {
+
+	private static Document doc = null;
+
+	public static void generateReport(Throwable ex, PhaseDefinition phaseDefinition) {
+
+		try {
+			final DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+			final DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+			doc = docBuilder.newDocument();
+
+			final Element rootElement = createTestsuiteElement(phaseDefinition, ex);
+			doc.appendChild(rootElement);
+
+			final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+			final Transformer transformer = transformerFactory.newTransformer();
+			final DOMSource source = new DOMSource(doc);
+			final File reportFile = new File("target/phaser-reports", "report-"
+					+ phaseDefinition.getJob().getClass().getSimpleName() + "-" + System.nanoTime() + ".xml");
+			reportFile.getParentFile().mkdirs();
+			reportFile.createNewFile();
+			final StreamResult result = new StreamResult(reportFile);
+			transformer.transform(source, result);
+
+			log.info("generated report at: " + reportFile.getAbsolutePath());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	private static Element createTestsuiteElement(PhaseDefinition phaseDefinition, Throwable ex) {
+		final Element elem = doc.createElement("testsuite");
+		final Element propsElem = doc.createElement("properties");
+		final Properties props = System.getProperties();
+		if (props != null) {
+			final Enumeration e = props.propertyNames();
+			while (e.hasMoreElements()) {
+				final String name = (String) e.nextElement();
+				final Element propElement = doc.createElement("property");
+				propElement.setAttribute("name", name);
+				propElement.setAttribute("value", props.getProperty(name));
+				propsElem.appendChild(propElement);
+			}
+		}
+		elem.appendChild(propsElem);
+		elem.setAttribute("name", phaseDefinition.getJob().getClass().toString());
+		elem.setAttribute("tests", "1");
+		elem.setAttribute("skipped", "0");
+		elem.setAttribute("failures", "0");
+		if (ex == null) {
+			elem.setAttribute("errors", "0");
+		} else {
+			elem.setAttribute("errors", "1");
+		}
+		elem.appendChild(createTestCaseElement(phaseDefinition, ex));
+		return elem;
+	}
+
+	private static Element createTestCaseElement(PhaseDefinition phaseDefinition, Throwable ex) {
+		final Element elem = doc.createElement("testcase");
+		elem.setAttribute("name", phaseDefinition.getMethod().getName());
+		elem.setAttribute("classname", phaseDefinition.getJob().getClass().getCanonicalName());
+		// TODO(jkasztur): implement time
+		elem.setAttribute("time", "0");
+		if (ex != null) {
+			final Element failElem = doc.createElement("failure");
+			failElem.setAttribute("message", "test failure");
+			// TODO(jkasztur): get real message error
+			failElem.setTextContent(ex.toString());
+			elem.appendChild(failElem);
+		}
+		return elem;
+	}
+
+	private XmlUtils() {
+	}
+}

--- a/src/test/java/org/jboss/qa/phaser/GenerateReportTest.java
+++ b/src/test/java/org/jboss/qa/phaser/GenerateReportTest.java
@@ -1,0 +1,65 @@
+package org.jboss.qa.phaser;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+import static junit.framework.Assert.assertTrue;
+
+import org.apache.commons.io.FileUtils;
+
+import org.jboss.qa.phaser.job.ReportJob;
+import org.jboss.qa.phaser.phase.second.SecondPhase;
+import org.jboss.qa.phaser.tools.SpyProxyFactory;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GenerateReportTest {
+
+	@Test
+	public void generateReportTest() throws Exception {
+		log.info("starting report test");
+		final SecondPhase scp = new SecondPhase();
+		final PhaseTreeBuilder builder = new PhaseTreeBuilder();
+
+		final ReportJob reportJob = mock(ReportJob.class);
+		final ReportJob reportproxy = SpyProxyFactory.createProxy(ReportJob.class, reportJob);
+		builder.addPhase(scp);
+		try {
+			new Phaser(builder.build(), reportproxy).run();
+		} catch (Exception ex) {
+			// OK
+		}
+		final File reportsDir = new File("target/phaser-reports");
+		assertTrue(reportsDir.exists());
+		assertEquals(2, reportsDir.listFiles().length);
+		final String successfulContent = FileUtils.readFileToString(reportsDir.listFiles()[0], "UTF-8");
+		final String failedContent = FileUtils.readFileToString(reportsDir.listFiles()[1], "UTF-8");
+		try {
+			testSuccesful(successfulContent);
+			testFailed(failedContent);
+		} catch (AssertionError ex) {
+			// in case of error swap files
+			testSuccesful(failedContent);
+			testFailed(successfulContent);
+		}
+	}
+
+	private void testSuccesful(String content) {
+		Assert.assertTrue(content.contains("errors=\"0\""));
+		Assert.assertTrue(content.contains("org.jboss.qa.phaser.job.ReportJob"));
+		Assert.assertTrue(content.contains("successPhase"));
+	}
+
+	private void testFailed(String content) {
+		Assert.assertTrue(content.contains("errors=\"1\""));
+		Assert.assertTrue(content.contains("org.jboss.qa.phaser.job.ReportJob"));
+		Assert.assertTrue(content.contains("failingPhase"));
+		Assert.assertTrue(content.contains("test failure"));
+	}
+}

--- a/src/test/java/org/jboss/qa/phaser/job/ReportJob.java
+++ b/src/test/java/org/jboss/qa/phaser/job/ReportJob.java
@@ -1,0 +1,30 @@
+package org.jboss.qa.phaser.job;
+
+import static org.jboss.qa.phaser.ExceptionHandling.Execution.CONTINUE;
+import static org.jboss.qa.phaser.ExceptionHandling.Report.SUPPRESS;
+
+import static junit.framework.Assert.fail;
+
+import org.jboss.qa.phaser.GenerateReport;
+import org.jboss.qa.phaser.OnException;
+import org.jboss.qa.phaser.phase.second.Second;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ReportJob {
+
+	@GenerateReport
+	@Second
+	public void successPhase() {
+		log.info("ReportJob[ID=Second#1]");
+	}
+
+	@OnException(execution = CONTINUE, report = SUPPRESS)
+	@GenerateReport
+	@Second
+	public void failingPhase() {
+		log.info("ReportJob[ID=Second#1]");
+		fail("expected fail");
+	}
+}


### PR DESCRIPTION
This will create xml reports for tests, so they can be uploaded to polarion:
```
<testsuite errors="1" failures="0" name="class org.jboss.qa.jenkins.jobs.DummyJob" skipped="0" tests="1">
	<properties>
		<property name="java.vendor" value="Oracle Corporation"/>
		<property name="sun.java.launcher" value="SUN_STANDARD"/>
  		 <!-- ... all system properties ... -->
		<property name="java.specification.version" value="1.8"/>
	</properties>
	<testcase classname="org.jboss.qa.jenkins.jobs.DummyJob" name="testMethod" time="0">
		<failure message="test failure">java.lang.reflect.InvocationTargetException</failure>
	</testcase>
</testsuite>
```